### PR TITLE
add Killall functionality

### DIFF
--- a/src/hs1.ts
+++ b/src/hs1.ts
@@ -53,6 +53,9 @@ export async function main(ns: NS) {
         debugPrint(`attempting to deploy ${hackToDeploy} to all servers; targeting ${hackTarget} ...`);
         // Deploy the hack script to each server
         for (const server of servers) {
+            // Kill all scripts on the server if requested
+            if (killAllFirst) ns.killall(server.name);
+            
             // Copy the requested hack script to the server
             ns.scp(hackToDeploy, server.name, `home`);
             if (ns.fileExists(hackToDeploy, server.name)) debugPrint(`deployed ${hackToDeploy} to ${server.name}`);


### PR DESCRIPTION
This pull request includes a modification to the `main` function in the `src/hs1.ts` file to add an option for killing all scripts on a server before deploying a new hack script. 

Key change:

* Added a conditional check to kill all scripts on a server if the `killAllFirst` flag is set before copying the hack script to the server. (`src/hs1.ts`, [src/hs1.tsR56-R58](diffhunk://#diff-d77b9a59695cb0f41cdf9b3bf1a7c790c7e2428c1050888af5a3874090854da4R56-R58))