### PR TITLE
Add Logger implementation

### DIFF
--- a/src/colorTable.ts
+++ b/src/colorTable.ts
@@ -1,0 +1,24 @@
+import { NS } from '@ns';
+
+/*
+ * This script generates a 256-color table in the terminal
+ * https://gist.github.com/dominikwilkowski/60eed2ea722183769d586c76f22098dd
+ * Colors are called using the format `\u001b[38;5;nm`
+ *   where n is the color code printed in the table
+ */
+
+export async function main(ns: NS) {
+    function generateColorTable() {
+        let line = '';
+        for (let n = 0; n <= 255; n++) {
+            const colorCode = `\u001b[38;5;${n}m`;
+            line += `${colorCode}${n}\u001b[0m `;
+            if ((n - 15) % 10 === 0) {
+                ns.tprint(line);
+                line = '';
+            }
+        }
+        if (line !== '') ns.tprint(line);
+    }
+    generateColorTable();
+}

--- a/src/helperLib.ts
+++ b/src/helperLib.ts
@@ -23,7 +23,7 @@ export class TerminalFormats {
 
     // Colors found using colorTable.ts
     static Info: Color = '\u001b[38;5;26m';
-    static Debug: Color = '\u001b[38;5;178m';
+    static Debug: Color = '\u001b[38;5;123m';
     static Error: Color = '\u001b[38;5;196m';
     
     // Standard Colors

--- a/src/helperLib.ts
+++ b/src/helperLib.ts
@@ -14,13 +14,19 @@ export const portOpeningPrograms = [
 export type Color = string;
 export type TextStyle = string;
 
-//https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
+// https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
+// https://gist.github.com/dominikwilkowski/60eed2ea722183769d586c76f22098dd
 export class TerminalFormats {
     static Reset: Color = '\u001b[0m';
     static Bold: TextStyle = '\u001b[1m';
     static Underline: TextStyle = '\u001b[4m'; 
 
+    // Colors found using colorTable.ts
+    static Info: Color = '\u001b[38;5;26m';
+    static Debug: Color = '\u001b[38;5;178m';
+    static Error: Color = '\u001b[38;5;196m';
     
+    // Standard Colors
     static Black: Color = '\u001b[30m';
     static Red: Color = '\u001b[31m';
     static Green: Color = '\u001b[32m';
@@ -54,32 +60,8 @@ export class TerminalFormats {
     static BrightMagentaBackground: Color = '\u001b[45;1m';
     static BrightCyanBackground: Color = '\u001b[46;1m';
     static BrightWhiteBackground: Color = '\u001b[47;1m';
-
-    
-
 }
 
 export function colorize(value: any, color: Color) {
     return `${color}${value}${TerminalFormats.Reset}`;
-}
-
-// colors found on reddit
-export const colors = {
-    Black: '\u001b[30m',
-    Red: '\u001b[31m',
-    Green: '\u001b[32m',
-    Yellow: '\u001b[33m',
-    Blue: '\u001b[34m',
-    Magenta: '\u001b[35m',
-    Cyan: '\u001b[36m',
-    White: '\u001b[37m',
-    BrightBlack: '\u001b[30;1m',
-    BrightRed: '\u001b[31;1m',
-    BrightGreen: '\u001b[32;1m',
-    BrightYellow: '\u001b[33;1m',
-    BrightBlue: '\u001b[34;1m',
-    BrightMagenta: '\u001b[35;1m',
-    BrightCyan: '\u001b[36;1m',
-    BrightWhite: '\u001b[37;1m',
-    Reset: '\u001b[0m',
 }

--- a/src/hs1.ts
+++ b/src/hs1.ts
@@ -52,12 +52,12 @@ export async function main(ns: NS) {
     try {
         homefilelist = ns.ls('home');
     } catch (error) {
-        Logger.error(ns, `Failed to list files on home server: ${error}`);
+        Logger.error(ns, `Failed to list files on home server: {0}`, error);
     }
 
     if (hackToDeploy !== '') {
         try {
-            Logger.debug(ns, `attempting to deploy ${hackToDeploy} to all servers; targeting ${hackTarget} ...`, debug);
+            Logger.debug(ns, `attempting to deploy {0} to all servers; targeting {1} ...`, debug, hackToDeploy, hackTarget);
             // Deploy the hack script to each server
             for (const server of servers) {
                 // Kill all scripts on the server if requested
@@ -65,27 +65,27 @@ export async function main(ns: NS) {
                 
                 // Copy the requested hack script to the server
                 ns.scp(hackToDeploy, server.name, `home`);
-                if (ns.fileExists(hackToDeploy, server.name)) Logger.debug(ns, `deployed ${hackToDeploy} to ${server.name}`, debug);
+                if (ns.fileExists(hackToDeploy, server.name)) Logger.debug(ns, `deployed {0} to {1}`, debug, hackToDeploy, server.name);
 
                 // NUKE the server if it doesn't have root access
                 if (!ns.hasRootAccess(server.name)) {
                     try {
                         ns.nuke(server.name);
                         if (ns.hasRootAccess(server.name)) {
-                            Logger.debug(ns, `${server.name} has been nuked`, debug);
+                            Logger.debug(ns, `{0} has been nuked`, debug, server.name);
                         } else {
                             throw new Error(`Failed to nuke ${server.name}`);
                         }
                     } catch (error) {
                         Logger.error(ns, `${error}`);
                     }} else {
-                    Logger.debug(ns, `${server.name} already has root access`, debug);
+                    Logger.debug(ns, `{0} already has root access`, debug, server.name);
                 }
 
             // Run the hack script on the server
-            Logger.debug(ns, `Attempting to execute ${hackToDeploy} on ${server.name} with ${server.threads} threads targetting ${hackTarget}`, debug);
+            Logger.debug(ns, `Attempting to execute {0} on {1} with {2} threads targetting {3}`, debug, hackToDeploy, server.name, server.threads, hackTarget);
             ns.exec(hackToDeploy, server.name, server.threads, hackTarget, debug);
-            if (ns.scriptRunning(hackToDeploy, server.name)) Logger.info(ns, `${hackToDeploy} is running on ${server.name}`);
+            if (ns.scriptRunning(hackToDeploy, server.name)) Logger.info(ns, `{0} is running on {1}`,hackToDeploy, server.name);
 
                 // Fetch files if requested
                 if (doFetch) {
@@ -93,14 +93,14 @@ export async function main(ns: NS) {
                         if (!homefilelist.includes(file) && server.name !== 'home')
                             try {
                                 ns.scp(file, `home`, server.name);
-                                Logger.info(ns, `...${file} fetched from ${server.name}`);
+                                Logger.info(ns, `...{0} fetched from {1}`, file, server.name);
                             }
-                            catch { Logger.error(ns, `...can't fetch ${file} from ${server.name}!`); }
+                            catch { Logger.error(ns, `...can't fetch {0} from {1}!`, file, server.name); }
                     });
                 }
             }
         } catch (error) {
-            Logger.error(ns, `Failed to deploy hack script: ${error}`);
+            Logger.error(ns, `Failed to deploy hack script: {0}`, error);
         }
     } else {
         Logger.error(ns, `no hack script to deploy. include script name!`);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,48 +1,35 @@
+import { TerminalFormats as colors, colorize } from './helperLib';
+
 /*
 * Logger class to log messages to the terminal with different log levels.
-* 
-* Doesn't function yet, this is just a placeholder for future development.
 */
 
-enum LogLevel {
-    INFO = 'INFO',
-    DEBUG = 'DEBUG',
-    ERROR = 'ERROR'
-}
+type LogLevel = 'INFO' | 'DEBUG' | 'ERROR';
+
+const logLevelColors: { [key in LogLevel]: string } = {
+    INFO: colors.Info,
+    DEBUG: colors.Debug,
+    ERROR: colors.Error
+};
 
 class Logger {
-    private static getColor(level: LogLevel): string {
-        switch (level) {
-            case LogLevel.INFO:
-                return '\x1b[34m'; // Blue
-            case LogLevel.DEBUG:
-                return '\x1b[33m'; // Yellow
-            case LogLevel.ERROR:
-                return '\x1b[31m'; // Red
-            default:
-                return '\x1b[0m'; // Reset
-        }
-    }
-
     private static formatMessage(level: LogLevel, message: string, ...variables: any[]): string {
-        const color = Logger.getColor(level);
-        const reset = '\x1b[0m';
-        const formattedVariables = variables.map(variable => `${color}${variable}${reset}`);
-        return `${color}[${level}]${reset} ${message} ${formattedVariables.join(' ')}`;
+        const formattedVariables = variables.map(variable => colorize(variable, logLevelColors[level]));
+        return `${colorize(`[${level}] ${message}`, logLevelColors[level])} ${formattedVariables.join(' ')}`;
     }
 
     static info(ns: any, message: string, ...variables: any[]): void {
-        ns.tprint(Logger.formatMessage(LogLevel.INFO, message, ...variables));
+        ns.tprint(Logger.formatMessage('INFO', message, ...variables));
     }
 
     static debug(ns: any, message: string, DEBUG: boolean, ...variables: any[]): void {
         if (DEBUG) {
-            ns.tprint(Logger.formatMessage(LogLevel.DEBUG, message, ...variables));
+            ns.tprint(Logger.formatMessage('DEBUG', message, ...variables));
         }
     }
 
     static error(ns: any, message: string, ...variables: any[]): void {
-        ns.tprint(Logger.formatMessage(LogLevel.ERROR, message, ...variables));
+        ns.tprint(Logger.formatMessage('ERROR', message, ...variables));
     }
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,47 @@
+/*
+* Logger class to log messages to the terminal with different log levels.
+* 
+* Doesn't function yet, this is just a placeholder for future development.
+*/
+
+enum LogLevel {
+    INFO = 'INFO',
+    DEBUG = 'DEBUG',
+    ERROR = 'ERROR'
+}
+
+class Logger {
+    private static getColor(level: LogLevel): string {
+        switch (level) {
+            case LogLevel.INFO:
+                return '\x1b[32m'; // Green
+            case LogLevel.DEBUG:
+                return '\x1b[34m'; // Blue
+            case LogLevel.ERROR:
+                return '\x1b[31m'; // Red
+            default:
+                return '\x1b[0m'; // Reset
+        }
+    }
+
+    private static formatMessage(level: LogLevel, message: string, ...variables: any[]): string {
+        const color = Logger.getColor(level);
+        const reset = '\x1b[0m';
+        const formattedVariables = variables.map(variable => `${color}${variable}${reset}`);
+        return `${color}[${level}]${reset} ${message} ${formattedVariables.join(' ')}`;
+    }
+
+    static info(ns: any, message: string, ...variables: any[]): void {
+        ns.tprint(Logger.formatMessage(LogLevel.INFO, message, ...variables));
+    }
+
+    static debug(ns: any, message: string, ...variables: any[]): void {
+        ns.tprint(Logger.formatMessage(LogLevel.DEBUG, message, ...variables));
+    }
+
+    static error(ns: any, message: string, ...variables: any[]): void {
+        ns.tprint(Logger.formatMessage(LogLevel.ERROR, message, ...variables));
+    }
+}
+
+export { Logger, LogLevel };

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -13,9 +13,19 @@ const logLevelColors: { [key in LogLevel]: string } = {
 };
 
 class Logger {
+    // ...used Copilot for this.  I never would have come up with this myself.
     private static formatMessage(level: LogLevel, message: string, ...variables: any[]): string {
-        const formattedVariables = variables.map(variable => colorize(variable, logLevelColors[level]));
-        return `${colorize(`[${level}] ${message}`, logLevelColors[level])} ${formattedVariables.join(' ')}`;
+        // Split the message into parts and apply the log level color to the entire message
+        let formattedMessage = message.split(/{(\d+)}/g).map((part, index) => {
+            // If the part is a placeholder, replace it with the corresponding variable colored magenta
+            if (index % 2 === 1) {
+                return colorize(variables[parseInt(part)], colors.Magenta);
+            }
+            // Otherwise, colorize the part with the log level color
+            return colorize(part, logLevelColors[level]);
+        }).join('');
+
+        return `${colorize(`[${level}]`, logLevelColors[level])} ${formattedMessage}`;
     }
 
     static info(ns: any, message: string, ...variables: any[]): void {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -14,9 +14,9 @@ class Logger {
     private static getColor(level: LogLevel): string {
         switch (level) {
             case LogLevel.INFO:
-                return '\x1b[32m'; // Green
-            case LogLevel.DEBUG:
                 return '\x1b[34m'; // Blue
+            case LogLevel.DEBUG:
+                return '\x1b[33m'; // Yellow
             case LogLevel.ERROR:
                 return '\x1b[31m'; // Red
             default:
@@ -35,8 +35,10 @@ class Logger {
         ns.tprint(Logger.formatMessage(LogLevel.INFO, message, ...variables));
     }
 
-    static debug(ns: any, message: string, ...variables: any[]): void {
-        ns.tprint(Logger.formatMessage(LogLevel.DEBUG, message, ...variables));
+    static debug(ns: any, message: string, DEBUG: boolean, ...variables: any[]): void {
+        if (DEBUG) {
+            ns.tprint(Logger.formatMessage(LogLevel.DEBUG, message, ...variables));
+        }
     }
 
     static error(ns: any, message: string, ...variables: any[]): void {

--- a/src/my-first-hack.ts
+++ b/src/my-first-hack.ts
@@ -5,12 +5,8 @@ import { NS } from '@ns';
 
 /** @param {NS} ns */
 export async function main(ns: NS) {
-  const DEBUG = ns.args[1];
-  function debugPrint(message: string) {
-    if (DEBUG) {
-      ns.tprint(`DEBUG: ${message}`);
-    }
-  }
+  // reporting is set to true if the debug flag is passed to the hack script
+  const reporting = ns.args[1] === true;
 
   // Defines the 'target server', which is the server
   // that we're going to hack. 
@@ -27,16 +23,16 @@ export async function main(ns: NS) {
     // Infinite loop that continously hacks/grows/weakens the target server
     if (ns.getServerSecurityLevel(target) > securityThresh) {
       // If the server's security level is above our threshold, weaken it
-      debugPrint(`${ns.getHostname()} 👇 ${target}`);
+      if (reporting) ns.tprint(`${ns.getHostname()} 👇 ${target}`);
       await ns.weaken(target);
     } else if (ns.getServerMoneyAvailable(target) < moneyThresh) {
       // If the server's money is less than our threshold, grow it
-      debugPrint(`${ns.getHostname()} 👆 ${target}`);
+      if (reporting) ns.tprint(`${ns.getHostname()} 👆 ${target}`);
       await ns.grow(target);
     } else {
       // Otherwise, hack it
       await ns.hack(target);
-      debugPrint(`${ns.getHostname()} 👉 ${target}`);
+      if (reporting) ns.tprint(`${ns.getHostname()} 👉 ${target}`);
     }
   }
 }


### PR DESCRIPTION
This pull request introduces a new `Logger` class for improved logging and makes several changes to utilize this logger across different scripts. Additionally, it includes a new script to generate a 256-color table and updates color definitions in the `TerminalFormats` class.

Key changes include:

### Logging Improvements:
* [`src/logger.ts`](diffhunk://#diff-7bc1140e724e284ae22084e1172568baa8d151063d02c75ed1d8805fa7796acaR1-R46): Introduced a new `Logger` class to log messages with different log levels (`INFO`, `DEBUG`, `ERROR`) and color-coded messages.
* [`src/hs1.ts`](diffhunk://#diff-d77b9a59695cb0f41cdf9b3bf1a7c790c7e2428c1050888af5a3874090854da4R14-R19): Replaced direct `ns.tprint` calls with `Logger` methods to standardize logging. [[1]](diffhunk://#diff-d77b9a59695cb0f41cdf9b3bf1a7c790c7e2428c1050888af5a3874090854da4R14-R19) [[2]](diffhunk://#diff-d77b9a59695cb0f41cdf9b3bf1a7c790c7e2428c1050888af5a3874090854da4L62-R107)

### Color Table Generation:
* [`src/colorTable.ts`](diffhunk://#diff-9d7f4f55260c535f078cfa97007c0ff6c0bb741771e72ae70bc183fdc61a24e8R1-R24): Added a new script to generate a 256-color table in the terminal, utilizing ANSI escape codes.

### Terminal Formats Update:
* [`src/helperLib.ts`](diffhunk://#diff-1f04d13c0e800ee7c8d5b8fccb10e7b4b8d8abde645c8ff2e33e5064e4ab1c49R18-R29): Updated the `TerminalFormats` class to include new color codes for `INFO`, `DEBUG`, and `ERROR` log levels. Removed redundant color definitions. [[1]](diffhunk://#diff-1f04d13c0e800ee7c8d5b8fccb10e7b4b8d8abde645c8ff2e33e5064e4ab1c49R18-R29) [[2]](diffhunk://#diff-1f04d13c0e800ee7c8d5b8fccb10e7b4b8d8abde645c8ff2e33e5064e4ab1c49L57-L85)

### Debugging Enhancements:
* [`src/my-first-hack.ts`](diffhunk://#diff-cbe7284645a350f7217561d8da38f9b84298b9a29507a7f04ea551bdea441623L8-R9): Simplified debugging by using a `reporting` flag instead of a separate debug function. [[1]](diffhunk://#diff-cbe7284645a350f7217561d8da38f9b84298b9a29507a7f04ea551bdea441623L8-R9) [[2]](diffhunk://#diff-cbe7284645a350f7217561d8da38f9b84298b9a29507a7f04ea551bdea441623L30-R35)