### PR TITLE
Logger updates

### DIFF
--- a/src/helperLib.ts
+++ b/src/helperLib.ts
@@ -22,9 +22,11 @@ export class TerminalFormats {
     static Underline: TextStyle = '\u001b[4m'; 
 
     // Colors found using colorTable.ts
-    static Info: Color = '\u001b[38;5;26m';
     static Debug: Color = '\u001b[38;5;123m';
+    static Info: Color = '\u001b[38;5;26m';
+    static Warn: Color = '\u001b[38;5;208m';
     static Error: Color = '\u001b[38;5;196m';
+    
     
     // Standard Colors
     static Black: Color = '\u001b[30m';

--- a/src/hs1.ts
+++ b/src/hs1.ts
@@ -72,7 +72,7 @@ export async function main(ns: NS) {
                     try {
                         ns.nuke(server.name);
                         if (ns.hasRootAccess(server.name)) {
-                            Logger.debug(ns, `{0} has been nuked`, debugFlag, server.name);
+                            Logger.info(ns, `{0} has been nuked`, server.name);
                         } else {
                             throw new Error(`Failed to nuke ${server.name}`);
                         }

--- a/src/hs1.ts
+++ b/src/hs1.ts
@@ -27,7 +27,7 @@ export async function main(ns: NS) {
         };
     }
 
-    const { includeHome, doFetch, killAllFirst, debug } = parseFlags(ns.args);
+    const { includeHome, doFetch, killAllFirst, debug: debugFlag } = parseFlags(ns.args);
 
     const hackToDeploy: string = ns.args[0]?.toString() || '';
     let hackTarget: string = DEFAULT_HACK_TARGET;
@@ -57,7 +57,7 @@ export async function main(ns: NS) {
 
     if (hackToDeploy !== '') {
         try {
-            Logger.debug(ns, `attempting to deploy {0} to all servers; targeting {1} ...`, debug, hackToDeploy, hackTarget);
+            Logger.debug(ns, `attempting to deploy {0} to all servers; targeting {1} ...`, debugFlag, hackToDeploy, hackTarget);
             // Deploy the hack script to each server
             for (const server of servers) {
                 // Kill all scripts on the server if requested
@@ -65,26 +65,26 @@ export async function main(ns: NS) {
                 
                 // Copy the requested hack script to the server
                 ns.scp(hackToDeploy, server.name, `home`);
-                if (ns.fileExists(hackToDeploy, server.name)) Logger.debug(ns, `deployed {0} to {1}`, debug, hackToDeploy, server.name);
+                if (ns.fileExists(hackToDeploy, server.name)) Logger.debug(ns, `deployed {0} to {1}`, debugFlag, hackToDeploy, server.name);
 
                 // NUKE the server if it doesn't have root access
                 if (!ns.hasRootAccess(server.name)) {
                     try {
                         ns.nuke(server.name);
                         if (ns.hasRootAccess(server.name)) {
-                            Logger.debug(ns, `{0} has been nuked`, debug, server.name);
+                            Logger.debug(ns, `{0} has been nuked`, debugFlag, server.name);
                         } else {
                             throw new Error(`Failed to nuke ${server.name}`);
                         }
                     } catch (error) {
                         Logger.error(ns, `${error}`);
                     }} else {
-                    Logger.debug(ns, `{0} already has root access`, debug, server.name);
+                    Logger.debug(ns, `{0} already has root access`, debugFlag, server.name);
                 }
 
                 // Run the hack script on the server
-                Logger.debug(ns, `Attempting to execute {0} on {1} with {2} threads targetting {3}`, debug, hackToDeploy, server.name, server.threads, hackTarget);
-                ns.exec(hackToDeploy, server.name, server.threads, hackTarget, debug);
+                Logger.debug(ns, `Attempting to execute {0} on {1} with {2} threads targetting {3}`, debugFlag, hackToDeploy, server.name, server.threads, hackTarget);
+                ns.exec(hackToDeploy, server.name, server.threads, hackTarget, debugFlag);
                 if (ns.scriptRunning(hackToDeploy, server.name)) Logger.info(ns, `{0} is running on {1} using {2} threads`,hackToDeploy, server.name, server.threads);
 
                 // Fetch files if requested
@@ -99,6 +99,7 @@ export async function main(ns: NS) {
                     });
                 }
             }
+            ns.toast('hacks deployed!');
         } catch (error) {
             Logger.error(ns, `Failed to deploy hack script: {0}`, error);
         }

--- a/src/hs1.ts
+++ b/src/hs1.ts
@@ -82,10 +82,10 @@ export async function main(ns: NS) {
                     Logger.debug(ns, `{0} already has root access`, debug, server.name);
                 }
 
-            // Run the hack script on the server
-            Logger.debug(ns, `Attempting to execute {0} on {1} with {2} threads targetting {3}`, debug, hackToDeploy, server.name, server.threads, hackTarget);
-            ns.exec(hackToDeploy, server.name, server.threads, hackTarget, debug);
-            if (ns.scriptRunning(hackToDeploy, server.name)) Logger.info(ns, `{0} is running on {1}`,hackToDeploy, server.name);
+                // Run the hack script on the server
+                Logger.debug(ns, `Attempting to execute {0} on {1} with {2} threads targetting {3}`, debug, hackToDeploy, server.name, server.threads, hackTarget);
+                ns.exec(hackToDeploy, server.name, server.threads, hackTarget, debug);
+                if (ns.scriptRunning(hackToDeploy, server.name)) Logger.info(ns, `{0} is running on {1} using {2} threads`,hackToDeploy, server.name, server.threads);
 
                 // Fetch files if requested
                 if (doFetch) {

--- a/src/hs2.ts
+++ b/src/hs2.ts
@@ -55,7 +55,7 @@ export async function main(ns: NS) {
 
         if (hackTarget) {
             Logger.debug(ns, 'attempting to deploy {0} to all servers; targeting {1} ...', debugFlag, hackToDeploy, hackTarget.hostname);
-            await matrix.deployHackOnAllServers(hackToDeploy, killAllFirst);
+            await matrix.deployHackOnAllServers(hackToDeploy, killAllFirst, debugFlag);
             await (async () => {
                 if (includeHome)
                     ns.run('start-home-server.js', 1, hackToDeploy, hackTarget.hostname);

--- a/src/hs2.ts
+++ b/src/hs2.ts
@@ -29,7 +29,7 @@ export async function main(ns: NS) {
         };
     }
 
-    const { includeHome, doFetch, killAllFirst, debug } = parseFlags(ns.args);
+    const { includeHome, doFetch, killAllFirst, debug: debugFlag } = parseFlags(ns.args);
 
     const hackToDeploy: string = ns.args[0]?.toString();
 
@@ -54,7 +54,7 @@ export async function main(ns: NS) {
         */
 
         if (hackTarget) {
-            Logger.info(ns, 'attempting to deploy {0} to all servers; targeting {1} ...', hackToDeploy, hackTarget.hostname);
+            Logger.debug(ns, 'attempting to deploy {0} to all servers; targeting {1} ...', debugFlag, hackToDeploy, hackTarget.hostname);
             await matrix.deployHackOnAllServers(hackToDeploy, killAllFirst);
             await (async () => {
                 if (includeHome)

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -21,8 +21,15 @@ class Logger {
             // If the part is a placeholder, replace it with the corresponding variable
             if (index % 2 === 1) {
                 const variable = variables[parseInt(part)];
-                // Colorize numbers as green, otherwise magenta
-                const color = typeof variable === 'number' ? colors.Green : colors.Magenta;
+                // Colorize numbers as green, .exe files as yellow, otherwise magenta
+                let color;
+                if (typeof variable === 'number') {
+                    color = colors.Green;
+                } else if (typeof variable === 'string' && variable.endsWith('.exe')) {
+                    color = colors.Yellow;
+                } else {
+                    color = colors.Magenta;
+                }
                 return colorize(variable, color);
             }
             // Otherwise, colorize the part with the log level color

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -4,11 +4,12 @@ import { TerminalFormats as colors, colorize } from './helperLib';
 * Logger class to log messages to the terminal with different log levels.
 */
 
-type LogLevel = 'INFO' | 'DEBUG' | 'ERROR';
+type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
 
 const logLevelColors: { [key in LogLevel]: string } = {
-    INFO: colors.Info,
     DEBUG: colors.Debug,
+    INFO: colors.Info,
+    WARN: colors.Warn,
     ERROR: colors.Error
 };
 
@@ -31,15 +32,20 @@ class Logger {
         return `${colorize(`[${level}]`, logLevelColors[level])} ${formattedMessage}`;
     }
 
-    static info(ns: any, message: string, ...variables: any[]): void {
-        ns.tprint(Logger.formatMessage('INFO', message, ...variables));
-    }
-
     static debug(ns: any, message: string, DEBUG: boolean, ...variables: any[]): void {
         if (DEBUG) {
             ns.tprint(Logger.formatMessage('DEBUG', message, ...variables));
         }
     }
+    
+    static info(ns: any, message: string, ...variables: any[]): void {
+        ns.tprint(Logger.formatMessage('INFO', message, ...variables));
+    }
+
+    static warn(ns: any, message: string, ...variables: any[]): void {
+        ns.tprint(Logger.formatMessage('WARN', message, ...variables));
+    }
+    
 
     static error(ns: any, message: string, ...variables: any[]): void {
         ns.tprint(Logger.formatMessage('ERROR', message, ...variables));

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -17,9 +17,12 @@ class Logger {
     private static formatMessage(level: LogLevel, message: string, ...variables: any[]): string {
         // Split the message into parts and apply the log level color to the entire message
         let formattedMessage = message.split(/{(\d+)}/g).map((part, index) => {
-            // If the part is a placeholder, replace it with the corresponding variable colored magenta
+            // If the part is a placeholder, replace it with the corresponding variable
             if (index % 2 === 1) {
-                return colorize(variables[parseInt(part)], colors.Magenta);
+                const variable = variables[parseInt(part)];
+                // Colorize numbers as green, otherwise magenta
+                const color = typeof variable === 'number' ? colors.Green : colors.Magenta;
+                return colorize(variable, color);
             }
             // Otherwise, colorize the part with the log level color
             return colorize(part, logLevelColors[level]);

--- a/src/server-matrix.ts
+++ b/src/server-matrix.ts
@@ -152,7 +152,7 @@ export class ServerMatrix {
                     throw `...hack deployment failed!`;
             }
             catch (err) {
-                Logger.error(ns, '{0}', err);
+                Logger.error(ns, `${err}`);
             }
         }
     }


### PR DESCRIPTION
This pull request includes several changes to enhance the logging functionality, improve the deployment scripts, and clean up the codebase. The most important changes include the addition of a warning log level, refactoring of debug flag usage, and the introduction of the `Logger` class for consistent logging.

### Improvements to logging:

* [`src/helperLib.ts`](diffhunk://#diff-1f04d13c0e800ee7c8d5b8fccb10e7b4b8d8abde645c8ff2e33e5064e4ab1c49L25-R30): Added a new `Warn` color to the `TerminalFormats` class.
* [`src/logger.ts`](diffhunk://#diff-7bc1140e724e284ae22084e1172568baa8d151063d02c75ed1d8805fa7796acaL7-R12): Introduced a new `WARN` log level and added corresponding methods in the `Logger` class. Updated the `formatMessage` method to colorize variables based on their type. [[1]](diffhunk://#diff-7bc1140e724e284ae22084e1172568baa8d151063d02c75ed1d8805fa7796acaL7-R12) [[2]](diffhunk://#diff-7bc1140e724e284ae22084e1172568baa8d151063d02c75ed1d8805fa7796acaL20-R33) [[3]](diffhunk://#diff-7bc1140e724e284ae22084e1172568baa8d151063d02c75ed1d8805fa7796acaL31-R56)

### Refactoring of debug flag usage:

* `src/hs1.ts` and `src/hs2.ts`: Renamed the `debug` variable to `debugFlag` for clarity and consistency. Updated all relevant method calls to use the new variable name. [[1]](diffhunk://#diff-d77b9a59695cb0f41cdf9b3bf1a7c790c7e2428c1050888af5a3874090854da4L30-R30) [[2]](diffhunk://#diff-d77b9a59695cb0f41cdf9b3bf1a7c790c7e2428c1050888af5a3874090854da4L60-R88) [[3]](diffhunk://#diff-d77b9a59695cb0f41cdf9b3bf1a7c790c7e2428c1050888af5a3874090854da4R102) [[4]](diffhunk://#diff-51196fc4d98d13fb45ec1588287b1ce2ca650eee69a5f6888e4a2f1125671f70L32-R32) [[5]](diffhunk://#diff-51196fc4d98d13fb45ec1588287b1ce2ca650eee69a5f6888e4a2f1125671f70L57-R58)

### Introduction of `Logger` class:

* [`src/server-matrix.ts`](diffhunk://#diff-21533591b8eb7635afd4023a2758908d6de4a11daaa3910d3ea9af880886bf56R2-R6): Replaced direct `ns.tprint` calls with `Logger` class methods for consistent logging. Added debug flag support in `deployHackOnAllServers` and `deployHackOnServer` methods. [[1]](diffhunk://#diff-21533591b8eb7635afd4023a2758908d6de4a11daaa3910d3ea9af880886bf56R2-R6) [[2]](diffhunk://#diff-21533591b8eb7635afd4023a2758908d6de4a11daaa3910d3ea9af880886bf56L32-R52) [[3]](diffhunk://#diff-21533591b8eb7635afd4023a2758908d6de4a11daaa3910d3ea9af880886bf56L115-R132) [[4]](diffhunk://#diff-21533591b8eb7635afd4023a2758908d6de4a11daaa3910d3ea9af880886bf56R141-R157) [[5]](diffhunk://#diff-21533591b8eb7635afd4023a2758908d6de4a11daaa3910d3ea9af880886bf56L165-R168) [[6]](diffhunk://#diff-21533591b8eb7635afd4023a2758908d6de4a11daaa3910d3ea9af880886bf56L182-R187) [[7]](diffhunk://#diff-21533591b8eb7635afd4023a2758908d6de4a11daaa3910d3ea9af880886bf56L253) [[8]](diffhunk://#diff-21533591b8eb7635afd4023a2758908d6de4a11daaa3910d3ea9af880886bf56L274-R279) [[9]](diffhunk://#diff-21533591b8eb7635afd4023a2758908d6de4a11daaa3910d3ea9af880886bf56L288-R302)