### PR TITLE
Add a deployable script that can share RAM with factions; Add a calla…

### DIFF
--- a/src/deployables/share.ts
+++ b/src/deployables/share.ts
@@ -1,0 +1,12 @@
+import { NS } from "@ns";
+
+/**
+ * @param {NS} ns Netscript namespace
+ */
+
+export async function main(ns: NS) {
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+        await ns.share();
+    }
+}

--- a/src/shareRAM.ts
+++ b/src/shareRAM.ts
@@ -1,0 +1,24 @@
+/*
+* created by j__r0d 2025-04-11
+*
+* This script is used to share RAM with the provided faction to increase the reputation gain
+* 
+* This script should deploy the share.js script to all servers that have RAM available
+* 
+* Usage: home; killall; run shareRAM.js
+*/
+
+import { NS } from '@ns';
+import { Logger } from './lib/logger';
+import { ServerMatrix } from './lib/server-matrix';
+
+export async function main(ns: NS) {
+    Logger.info(ns, 'shareRAM initiated...');
+
+    const matrix = new ServerMatrix(ns);
+    await matrix.initialize(ns, false);
+    const shareScript = './deployables/share.js';
+    if (!ns.fileExists(shareScript, 'home')) throw new Error(`${shareScript} does not exist!!`);
+    
+    await matrix.deployHackOnAllServers(shareScript, true, true, true);
+}


### PR DESCRIPTION
This pull request introduces two new scripts aimed at improving the reputation gain by sharing RAM with a faction. The changes include the addition of a new script for continuous sharing and a script for deploying the share script across all servers with available RAM.

New script additions:

* [`src/deployables/share.ts`](diffhunk://#diff-317c31216565d1ba3a14a2c51f7b87b9adf0110776f0e573aa18b9f80e28633aR1-R12): Added a script that continuously calls the `share` function in an infinite loop to increase reputation gain.
* [`src/shareRAM.ts`](diffhunk://#diff-ea34afbf5f9752571dba96eeae4782fdf83593785bbef5a5916cfdc29e4351eeR1-R24): Added a script to deploy the `share.ts` script to all servers with available RAM, including initialization of a server matrix and logging.