### PR TITLE
add time to each log entry

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -16,6 +16,7 @@ const logLevelColors: { [key in LogLevel]: string } = {
 class Logger {
     // ...used Copilot for this.  I never would have come up with this myself.
     private static formatMessage(level: LogLevel, message: string, ...variables: any[]): string {
+        const timestamp = new Date().toLocaleTimeString('en-US', { hour12: false }); // Generate a timestamp in HH:mm:ss format
         // Split the message into parts and apply the log level color to the entire message
         const formattedMessage = message.split(/{(\d+)}/g).map((part, index) => {
             // If the part is a placeholder, replace it with the corresponding variable
@@ -36,7 +37,7 @@ class Logger {
             return colorize(part, logLevelColors[level]);
         }).join('');
 
-        return `${colorize(`[${level}]`, logLevelColors[level])} ${formattedMessage}`;
+        return `${colorize(`[${level}: ${timestamp}]`, logLevelColors[level])} ${formattedMessage}`;
     }
 
     static debug(ns: any, message: string, DEBUG: boolean, ...variables: any[]): void {


### PR DESCRIPTION
This pull request introduces a timestamp to log messages in the `Logger` class, enhancing the clarity and usefulness of logs by including the time of each log entry.

### Logging Enhancements:

* [`src/lib/logger.ts`](diffhunk://#diff-73c4d73d75765ab186de329bbcb17bd1789967299b04fa88375c4a44a1797a27R19): Added a timestamp in HH:mm:ss format to log messages by generating it using `new Date().toLocaleTimeString`. The timestamp is now included in the formatted log output alongside the log level. [[1]](diffhunk://#diff-73c4d73d75765ab186de329bbcb17bd1789967299b04fa88375c4a44a1797a27R19) [[2]](diffhunk://#diff-73c4d73d75765ab186de329bbcb17bd1789967299b04fa88375c4a44a1797a27L39-R40)